### PR TITLE
Allow files exported by LibreOffice to validate

### DIFF
--- a/src/mso.xml
+++ b/src/mso.xml
@@ -1570,8 +1570,6 @@
 			<limitation expression="&lt;=4" />
 		</uint16>
 		<type name="pf" type="TextPFException">
-			<limitation name="masks.leftMargin" value="false" />
-			<limitation name="masks.indent" value="false" />
 			<limitation name="masks.defaultTabSize" value="false" />
 			<limitation name="masks.tabStops" value="false" />
 		</type>


### PR DESCRIPTION
An apparent bug in the LibreOffice PPT exporter makes it output files
which technically don't conform to the PPT specification.

When loading a drawing each text paragraph in the drawing has a
TextPFRun structure ("A structure that specifies the paragraph-level
formatting of a run of text"). This starts with a mask, followed by a
sequence of fields. Only unmasked fields are included in the sequence.

According to Section 2.9.45 of the PPT specification version 6, the
following fields must be masked out:

masks.leftMargin
masks.indent
masks.defaultTabSize
masks.tabStops

In spite of this LibreOffice incorrectly includes the leftMargin and
indent fields (flags 0x100 and 0x400).

This patch loosens PPT requirements to allow files with these flags set
to pass validation.

I've also created a Calligra patch to apply this change: https://phabricator.kde.org/D25256